### PR TITLE
SEO-204026-Image-Alt-Missing--Hotfix 

### DIFF
--- a/TypeScript/Accordion/Keyboard-Navigation.md
+++ b/TypeScript/Accordion/Keyboard-Navigation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Keyboard-Navigation
-description: keyboard navigation
+title: Keyboard-Navigation | Typescript | Syncfusion
+description: Check out and learn here all about keyboard navigation in Syncfusion TypeScript Accordion and much more details.
 platform: Typescript
 control: Accordion 
 documentation: ug
@@ -108,6 +108,6 @@ module AccordionComponent {
 
 Output for Accordion widget focused and navigated to last item using Keyboard navigation is as follows.
 
-![](Keyboard-Navigation_images/Keyboard-Navigation_img1.png) 
+![Configure keyboard interaction in keyboard navigation.](Keyboard-Navigation_images/Keyboard-Navigation_img1.png) 
 
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204388|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha