### PR TITLE
SEO-205214-Image-Alt-Missing-Typescript-Hotfix

### DIFF
--- a/TypeScript/Accordion/Keyboard-Navigation.md
+++ b/TypeScript/Accordion/Keyboard-Navigation.md
@@ -108,6 +108,6 @@ module AccordionComponent {
 
 Output for Accordion widget focused and navigated to last item using Keyboard navigation is as follows.
 
-![](Keyboard-Navigation_images/Keyboard-Navigation_img1.png) 
+![Configure keyboard interaction in TypeScript Accordion.](Keyboard-Navigation_images/Keyboard-Navigation_img1.png) 
 
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|




Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha